### PR TITLE
feat: apply time-range filter to audits-changes

### DIFF
--- a/cider-ci/generators/feature-tasks.yml
+++ b/cider-ci/generators/feature-tasks.yml
@@ -9,10 +9,20 @@
     FEATURE_NAME: "Audits as an system admin after I edited a user 02"
     FEATURE: './spec/features/audits/core_spec.rb[1:1:1:2]'
 './spec/features/audits/user_requests_spec.rb[1:1]':
-  name: "User's requests 01"
+  name: "User's audited requests 01"
   environment_variables:
-    FEATURE_NAME: "User's requests 01"
+    FEATURE_NAME: "User's audited requests 01"
     FEATURE: './spec/features/audits/user_requests_spec.rb[1:1]'
+'./spec/features/audits/user_requests_spec.rb[1:2]':
+  name: "User's audited requests 02"
+  environment_variables:
+    FEATURE_NAME: "User's audited requests 02"
+    FEATURE: './spec/features/audits/user_requests_spec.rb[1:2]'
+'./spec/features/audits/user_requests_spec.rb[1:3]':
+  name: "User's audited requests 03"
+  environment_variables:
+    FEATURE_NAME: "User's audited requests 03"
+    FEATURE: './spec/features/audits/user_requests_spec.rb[1:3]'
 './spec/features/breadcrumbs/inventory_pools_spec.rb[1:1:1:1]':
   name: "Breadcrumbs  an admin and a pool an system admin via the UI 01"
   environment_variables:

--- a/spec/factories/audited_change.rb
+++ b/spec/factories/audited_change.rb
@@ -1,2 +1,12 @@
 class AuditedChange < Sequel::Model
 end
+
+FactoryBot.define do
+  factory :audited_change do
+    txid { SecureRandom.uuid }
+    tg_op { "UPDATE" }
+    table_name { "test_changes" }
+    changed { {} }
+    created_at { Time.now }
+  end
+end

--- a/spec/features/audits/user_requests_spec.rb
+++ b/spec/features/audits/user_requests_spec.rb
@@ -1,11 +1,51 @@
 require "spec_helper"
 require "pry"
 
-feature "User's requests" do
+feature "User's audited requests" do
   before :each do
     @system_admin = FactoryBot.create :system_admin
+    @user = FactoryBot.create(:user)
     sign_in_as @system_admin
     @user = FactoryBot.create :user
+  end
+
+  let(:today) { Date.today }
+
+  def expect_changes_count(txid, start_date, expected_count)
+    formatted_date = start_date.is_a?(Date) ? start_date.strftime("%Y-%m-%d") : start_date.to_s
+    visit "/admin/audited/changes/"
+    fill_in "txid", with: txid
+    fill_in "start-date", with: formatted_date
+    select "test_changes", from: "table"
+
+    actual_count = all("table.audited-changes tbody tr").count
+    expect(actual_count).to eq(expected_count),
+      "Expected #{expected_count} rows, got #{actual_count} for start_date '#{formatted_date}'"
+    expect(page).to have_selector("table.audited-changes tbody tr", count: expected_count)
+  end
+
+  def except_changes_counts(txid, today)
+    expect_changes_count(txid, today - 14, 2)   # 2 weeks ago
+    expect_changes_count(txid, today << 1, 3)   # 1 month ago
+    expect_changes_count(txid, today << 12, 4)  # 1 year ago
+    expect_changes_count(txid, today << 60, 5)  # 5 years ago
+  end
+
+  def create_changes_test_data(txid)
+    [3.days.ago,
+      10.days.ago,
+      20.days.ago,
+      5.months.ago,
+      3.years.ago].each do |time|
+      FactoryBot.create(
+        :audited_change,
+        txid: txid,
+        tg_op: "UPDATE",
+        table_name: "test_changes",
+        changed: {},
+        created_at: time
+      )
+    end
   end
 
   scenario "works" do
@@ -13,7 +53,8 @@ feature "User's requests" do
     click_on "Edit"
     fill_in "firstname", with: "FooHans"
     click_on "Save"
-    wait_until { current_path == "/admin/users/#{@user.id}" }
+    expect(page).to have_current_path("/admin/users/#{@user.id}")
+    expect(page).to have_content("FooHans")
 
     visit "/admin/users/#{@system_admin.id}"
     click_on "Show Audit Requests"
@@ -26,10 +67,47 @@ feature "User's requests" do
 
     visit "/admin/audited/changes/"
     fill_in "txid", with: req.txid
-    wait_until do
-      all("table.audited-changes tbody tr").count == 1
-    end
+    expect(page).to have_selector("table.audited-changes tbody tr", count: 1)
     click_on "Change"
     expect(page).to have_content req.txid
+  end
+
+  scenario "filters audited changes correctly by time range" do
+    visit "/admin/users/#{@user.id}"
+    click_on "Edit"
+    fill_in "firstname", with: "FooHans"
+    click_on "Save"
+    expect(page).to have_current_path("/admin/users/#{@user.id}")
+    expect(page).to have_content("FooHans")
+
+    visit "/admin/users/#{@system_admin.id}"
+    click_on "Show Audit Requests"
+    req = AuditedRequest.where(user_id: @system_admin.id).order(:created_at).last
+    txid = req.txid
+    create_changes_test_data(txid)
+
+    expect_changes_count(txid, today - 7, 1)   # 1 week ago
+    except_changes_counts(txid, today)
+  end
+
+  scenario "filters audited changes after init by time range" do
+    visit "/admin/users/#{@user.id}"
+    click_on "Edit"
+    fill_in "firstname", with: "FooHans"
+    click_on "Save"
+    expect(page).to have_current_path("/admin/users/#{@user.id}")
+    expect(page).to have_content("FooHans")
+
+    visit "/admin/users/#{@system_admin.id}"
+    click_on "Show Audit Requests"
+
+    req = AuditedRequest.where(user_id: @system_admin.id).order(:created_at).last
+    txid = req.txid
+    create_changes_test_data(txid)
+    visit "/admin/audited/changes/?table=test_changes"
+
+    expect(page).to have_selector("table.audited-changes tbody tr", count: 1)
+
+    except_changes_counts(txid, today)
   end
 end

--- a/src/leihs/admin/resources/audits/changes/main.cljs
+++ b/src/leihs/admin/resources/audits/changes/main.cljs
@@ -1,5 +1,6 @@
 (ns leihs.admin.resources.audits.changes.main
   (:require
+   ["date-fns" :refer [subDays format parseISO isAfter isValid]]
    [accountant.core :as accountant]
    [cljs.pprint :refer [pprint]]
    [clojure.string :refer [join]]
@@ -42,6 +43,49 @@
      (concat [["(any)" ""]]
              tables))))
 
+;;; helper ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn normalize-date-str [s]
+  (cond
+    ;; Compact digits: YYYYMMDD -> YYYY-MM-DD
+    (re-matches #"^\d{8}$" s)
+    (let [y (subs s 0 4)
+          m (subs s 4 6)
+          d (subs s 6 8)]
+      (str y "-" m "-" d))
+
+    ;; Compact digits: YYYYMM -> YYYY-MM
+    (re-matches #"^\d{6}$" s)
+    (let [y (subs s 0 4)
+          m (subs s 4 6)]
+      (str y "-" m))
+
+    :else
+    (let [[_ y m d] (re-matches #"^(\d{1,6})(?:-(\d{1,2}))?(?:-(\d{1,2}))?$" s)
+          y4 (when y (subs y 0 (min 4 (count y))))
+          m2 (when m (if (= 1 (count m)) (str "0" m) m))
+          d2 (when d (if (= 1 (count d)) (str "0" d) d))]
+      (cond
+        (and y4 m2 d2) (str y4 "-" m2 "-" d2)
+        (and y4 m2)    (str y4 "-" m2)
+        :else          s))))
+
+(defn year-gte-1900? [s]
+  (when (= 10 (count s))
+    (let [y-str (subs s 0 4)
+          y (js/parseInt y-str 10)]
+      (>= y 1900))))
+
+(defn valid-date-str? [s]
+  (when (= 10 (count s))
+    (let [d (parseISO s)]
+      (and (isValid d) (year-gte-1900? s)))))
+
+(defn invalid-date-str? [s]
+  (cond
+    (< (count s) 10) false
+    :else (not (valid-date-str? s))))
+
 ;;; filters ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn table-filter-component []
@@ -78,6 +122,100 @@
                      (map (fn [op] [op op])))]
       ^{:key n} [:option {:value v} n])]])
 
+(defn date-filter
+  [key-kw id-str label-text input-atom update-range! update-range-debounced! invalid?]
+  [:div.form-group.m-2
+   [:label {:for id-str}
+    [:span (str label-text " ") [:small.text-monospace (str "(" id-str ")")]]]
+   [(keyword (str "input#" id-str ".form-control"))
+    {:type "date"
+     :min "1900-01-01"
+     :class (str "form-control" (when @invalid? " is-invalid"))
+     :value @input-atom
+     :on-change #(update-range-debounced! key-kw (.. % -target -value))
+     :on-input  #(update-range-debounced! key-kw (.. % -target -value))
+     :on-key-up (fn [e]
+                  (let [val (.. e -target -value)
+                        key (.-key e)]
+                    (if (= key "Enter")
+                      (update-range! key-kw val)
+                      (update-range-debounced! key-kw val))))
+     :on-blur #(update-range! key-kw (.. % -target -value))}]
+   (when @invalid?
+     [:div.invalid-feedback "Please enter a valid date (>= 1900-01-01)."])])
+
+(defn time-range-filter-component []
+  (let [query-params (merge default-query-params
+                            (:query-params-raw @routing/state*))
+        fmt-date #(format % "yyyy-MM-dd")
+        today (js/Date.)
+        one-week-ago (subDays today 7)
+        start-date (reagent/atom (or (not-empty (:start-date query-params))
+                                     (fmt-date one-week-ago)))
+        end-date   (reagent/atom (or (not-empty (:end-date query-params))
+                                     (fmt-date today)))
+        start-input (reagent/atom @start-date)
+        end-input   (reagent/atom @end-date)
+        start-invalid? (reagent/atom false)
+        end-invalid?   (reagent/atom false)
+        timeout-id (atom nil)
+        ensure-valid-range! (fn []
+                              (let [sd-str @start-date
+                                    ed-str @end-date
+                                    sd (when (= 10 (count sd-str)) (parseISO sd-str))
+                                    ed (when (= 10 (count ed-str)) (parseISO ed-str))]
+                                (when (and sd ed (isValid sd) (isValid ed)
+                                           (year-gte-1900? sd-str)
+                                           (year-gte-1900? ed-str)
+                                           (isAfter sd ed))
+                                  (reset! start-date (fmt-date (subDays ed 7)))
+                                  (reset! start-input @start-date)
+                                  (js/console.warn "⚠ adjusted start-date ->" @start-date))))
+        update-range! (fn [k v]
+                        (let [v* (normalize-date-str v)]
+                          (when @timeout-id
+                            (js/clearTimeout @timeout-id)
+                            (reset! timeout-id nil))
+                          (case k
+                            :start (do (reset! start-date v*) (reset! start-input v*)
+                                       (reset! start-invalid? (invalid-date-str? v*)))
+                            :end   (do (reset! end-date v*) (reset! end-input v*)
+                                       (reset! end-invalid? (invalid-date-str? v*))))
+                          (ensure-valid-range!)
+                          (let [sd-str @start-date
+                                ed-str @end-date
+                                curr (:query-params-raw @routing/state*)]
+                            (when (and (valid-date-str? sd-str)
+                                       (valid-date-str? ed-str)
+                                       (or (not= (:start-date curr) sd-str)
+                                           (not= (:end-date curr) ed-str)))
+                              (accountant/navigate!
+                               (page-path-for-query-params
+                                {:page 1
+                                 :start-date sd-str
+                                 :end-date ed-str}))))))
+        update-invalid-flags! (fn []
+                                (reset! start-invalid? (invalid-date-str? @start-input))
+                                (reset! end-invalid?   (invalid-date-str? @end-input)))
+        debounced-update-range! (fn [k v]
+                                  (case k
+                                    :start (reset! start-input v)
+                                    :end   (reset! end-input v))
+                                  (update-invalid-flags!)
+                                  (when @timeout-id
+                                    (js/clearTimeout @timeout-id))
+                                  (let [nv (normalize-date-str v)]
+                                    (reset! timeout-id
+                                            (js/setTimeout
+                                             (fn []
+                                               (when (valid-date-str? nv)
+                                                 (update-range! k nv)))
+                                             filter/DURATION_DEBOUNCE))))]
+    (fn []
+      [:div.d-flex.flex-wrap
+       [date-filter :start "start-date" "Start date" start-input update-range! debounced-update-range! start-invalid?]
+       [date-filter :end   "end-date"   "End date"   end-input   update-range! debounced-update-range! end-invalid?]])))
+
 (defn filter-component []
   [filter/container
    [:<>
@@ -94,6 +232,7 @@
      :query-params-key :pkey]
     [table-filter-component]
     [tg-op-filter-component]
+    [time-range-filter-component]
     [filter/form-per-page]
     [filter/reset :default-query-params default-query-params]]])
 

--- a/src/leihs/admin/resources/audits/changes/shared.cljc
+++ b/src/leihs/admin/resources/audits/changes/shared.cljc
@@ -7,6 +7,8 @@
    :pkey ""
    :table ""
    :term ""
+   :start-date ""
+   :end-date ""
    :tg-op ""
    :per-page defaults/PER-PAGE})
 


### PR DESCRIPTION
https://github.com/leihs/leihs/issues/2006

Old PR: https://github.com/leihs/leihs-admin/pull/8

1. Debounce duration for input-fields
2. start-/end-date for audits-change
3. Init state: start-date= now-1week
4. if end-date < start-date: start-date=enddate-1week
5. Date validation & debounce